### PR TITLE
fix canvas rotation disabling betteredit hook permanently

### DIFF
--- a/src/modules/CanvasRotate/CanvasRotate.cpp
+++ b/src/modules/CanvasRotate/CanvasRotate.cpp
@@ -5,20 +5,23 @@
 using namespace tinker::ui;
 
 void CanvasRotate::onEditor() {
-    if (auto betterEdit = tinker::utils::getMod<"hjfod.betteredit">()) {
-        for (auto hook : betterEdit->getHooks()) {
-            if (hook->getDisplayName() == "EditorUI::scrollWheel") {
-                (void) hook->disable();
-                break;
-            }
-        }
-    }
-
     m_rotationNode = RotationNode::create(m_editorUI);
     m_rotationNode->setID("rotation-node"_spr);
     m_editorUI->addChild(m_rotationNode);
 
     m_editorLoaded = true;
+
+    auto betterEdit = tinker::utils::getMod<"hjfod.betteredit">();
+    if (!betterEdit) return;
+
+    bool enabled = CanvasRotate::isEnabled();
+
+    for (auto hook : betterEdit->getHooks()) {
+        if (hook->getDisplayName() == "EditorUI::scrollWheel") {
+            (void) hook->toggle(enabled);
+            break;
+        }
+    }
 }
 
 void CREditorUI::moveObject(GameObject* p0, CCPoint p1) {

--- a/src/modules/CanvasRotate/CanvasRotate.cpp
+++ b/src/modules/CanvasRotate/CanvasRotate.cpp
@@ -4,17 +4,9 @@
 
 using namespace tinker::ui;
 
-void CanvasRotate::onEditor() {
-    m_rotationNode = RotationNode::create(m_editorUI);
-    m_rotationNode->setID("rotation-node"_spr);
-    m_editorUI->addChild(m_rotationNode);
-
-    m_editorLoaded = true;
-
+void toggleBetterEditHook(bool enabled) {
     auto betterEdit = tinker::utils::getMod<"hjfod.betteredit">();
     if (!betterEdit) return;
-
-    bool enabled = CanvasRotate::isEnabled();
 
     for (auto hook : betterEdit->getHooks()) {
         if (hook->getDisplayName() == "EditorUI::scrollWheel") {
@@ -22,6 +14,25 @@ void CanvasRotate::onEditor() {
             break;
         }
     }
+}
+
+void CanvasRotate::onEditor() {
+    toggleBetterEditHook(false);
+
+    m_rotationNode = RotationNode::create(m_editorUI);
+    m_rotationNode->setID("rotation-node"_spr);
+    m_editorUI->addChild(m_rotationNode);
+
+    m_editorLoaded = true;
+}
+
+$on_mod(Loaded) {
+    bool enabled = Mod::get()->getSettingValue<bool>("CanvasRotate-enabled");
+    toggleBetterEditHook(!enabled);
+
+    listenForSettingChanges<bool>("CanvasRotate-enabled", [] (bool enabled) {
+        toggleBetterEditHook(!enabled);
+    });
 }
 
 void CREditorUI::moveObject(GameObject* p0, CCPoint p1) {


### PR DESCRIPTION
bug repro:

1. enable canvas rotate
2. enter editor (for the first time)
3. disable canvas rotate
4. re-enter editor
5. betteredit's `EditorUI::scrollWheel` hook is still disabled

at first i thought this was a bug where the betteredit hook would always be disabled but no you just have to restart your game :) so it's not that severe really but still worth fixing i think