### PR TITLE
improve performance in `ModuleCore::isEnabled`

### DIFF
--- a/src/Module.hpp
+++ b/src/Module.hpp
@@ -80,8 +80,8 @@ public:
         static constexpr auto enabledKey = tinker::utils::concat<Name, "-enabled">();
         static auto setting = Mod::get()->getSetting(enabledKey.data());
         if (!setting) return false;
-        bool settingEnabled = setting->shouldEnable();
-        return getSetting<bool, "enabled">() && settingEnabled;
+        static bool settingEnabled = setting->shouldEnable();
+        return settingEnabled && getSetting<bool, "enabled">();
     }
 
     template <class S, geode::utils::string::ConstexprString key>


### PR DESCRIPTION
currently this mod creates some unnecessary lag due to frequent setting calls. this is because `ModuleCore::isEnabled` is called very frequently due it being in the `setPropertiesForObject` lambda in `DurationDrag.cpp`. most of the function is cached, however currently `setting->shouldEnable()` isn't cached. when called on an enable-if scheme that checks for if a mod is loaded (which is true for all current enable-if schemes), this function is called:

```cpp
bool shouldEnableSetting(std::string_view defaultModID) const override {
    if (Loader::get()->getLoadedMod(modID)) {
        return true;
    }
    auto modName = modID;
    if (auto mod = Loader::get()->getInstalledMod(modID)) {
        modName = mod->getName();
    }
    return false;
}
```

both `getLoadedMod` and `getInstalledMod` are quite costly when called so often, which causes the lag

the solution is to make settingEnabled static. this isn't very rigorous as if the setting enabled scheme relies on another setting that can change it'll break. maybe a better solution would be parsing the enable-if string ourselves but this works for now